### PR TITLE
Preserve error stacktrace on various query or transaction errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.8
+
+- Preserve error stacktrace on various query or transaction errors.
+
 ## 0.9.7
 
 - Adds `Connection.mappedResultsQuery` to return query results as a `Map` with keys for table and column names.

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -420,7 +420,7 @@ class PostgreSQLConnection implements PostgreSQLExecutionContext {
       var exception =
           new PostgreSQLException("Connection closed or query cancelled (reason: $error).", stackTrace: stackTrace);
       queries?.forEach((q) {
-        q.completeError(exception);
+        q.completeError(exception, stackTrace);
       });
     });
   }

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -182,9 +182,9 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);
-    } catch (e) {
+    } catch (e, st) {
       scheduleMicrotask(() {
-        q.completeError(e);
+        q.completeError(e, st);
         connection._transitionToState(new _PostgreSQLConnectionStateIdle());
       });
 
@@ -301,9 +301,9 @@ class _PostgreSQLConnectionStateReadyInTransaction extends _PostgreSQLConnection
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);
-    } catch (e) {
+    } catch (e, st) {
       scheduleMicrotask(() {
-        q.completeError(e);
+        q.completeError(e, st);
         connection._transitionToState(new _PostgreSQLConnectionStateTransactionFailure(transaction));
       });
 

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -138,8 +138,8 @@ class Query<T> {
     _onComplete.complete(rows);
   }
 
-  void completeError(dynamic error) {
-    _onComplete.completeError(error);
+  void completeError(dynamic error, [StackTrace stackTrace]) {
+    _onComplete.completeError(error, stackTrace);
   }
 
   String toString() => statement;

--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -78,11 +78,11 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
       await execute("ROLLBACK");
       completer.complete(new PostgreSQLRollback._(rollback.reason));
       return;
-    } catch (e) {
+    } catch (e, st) {
       queryQueue = [];
 
       await execute("ROLLBACK");
-      completer.completeError(e);
+      completer.completeError(e, st);
       return;
     }
 
@@ -104,11 +104,11 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
 
       connection._cacheQuery(query);
       queryQueue.remove(query);
-    } catch (e) {
+    } catch (e, st) {
       queryQueue = [];
 
       await execute("ROLLBACK");
-      completer.completeError(e);
+      completer.completeError(e, st);
       return null;
     }
 


### PR DESCRIPTION
Makes debugging much easier.