### PR TITLE
Adds tests and fixes some async issues in transaction

### DIFF
--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -113,15 +113,7 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
     if (!_hasFailed) {
       _hasFailed = true;
       queryQueue = [];
-
-      try {
-        await execute("ROLLBACK");
-      } catch (_) {
-        await connection.close();
-        completer.completeError(error, trace);
-        rethrow;
-      }
-
+      await execute("ROLLBACK");
       completer.completeError(error, trace);
     }
   }


### PR DESCRIPTION
- Fixes issue where a transaction closure would continue executing when a query throws. Subsequent queries were not run, but that the code ran could still lead to other bugs.

- Ensure that transactions are tore down correctly if an unawaited query throws.