### PR TITLE
refactor query caching into a separate object to reduce code in Query…

### DIFF
--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -178,7 +178,7 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
         return new _PostgreSQLConnectionStateBusy(q);
       }
 
-      var cached = connection._cache[q.statement];
+      final cached = connection._cache[q.statement];
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);
@@ -297,7 +297,7 @@ class _PostgreSQLConnectionStateReadyInTransaction extends _PostgreSQLConnection
         return new _PostgreSQLConnectionStateBusy(q);
       }
 
-      var cached = connection._cache[q.statement];
+      final cached = connection._cache[q.statement];
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -178,7 +178,7 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
         return new _PostgreSQLConnectionStateBusy(q);
       }
 
-      var cached = connection._cachedQuery(q.statement);
+      var cached = connection._cache[q.statement];
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);
@@ -297,7 +297,7 @@ class _PostgreSQLConnectionStateReadyInTransaction extends _PostgreSQLConnection
         return new _PostgreSQLConnectionStateBusy(q);
       }
 
-      var cached = connection._cachedQuery(q.statement);
+      var cached = connection._cache[q.statement];
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -35,7 +35,7 @@ class Query<T> {
 
   List<dynamic> rows = [];
 
-  QueryCache cache;
+  CachedQuery cache;
 
   void sendSimple(Socket socket) {
     var sqlString = PostgreSQLFormat.substitute(statement, substitutionValues);
@@ -44,7 +44,7 @@ class Query<T> {
     socket.add(queryMessage.asBytes());
   }
 
-  void sendExtended(Socket socket, {QueryCache cacheQuery: null}) {
+  void sendExtended(Socket socket, {CachedQuery cacheQuery: null}) {
     if (cacheQuery != null) {
       fieldDescriptions = cacheQuery.fieldDescriptions;
       sendCachedQuery(socket, cacheQuery, substitutionValues);
@@ -74,13 +74,13 @@ class Query<T> {
     ];
 
     if (statementIdentifier != null) {
-      cache = new QueryCache(statementIdentifier, formatIdentifiers);
+      cache = new CachedQuery(statementIdentifier, formatIdentifiers);
     }
 
     socket.add(ClientMessage.aggregateBytes(messages));
   }
 
-  void sendCachedQuery(Socket socket, QueryCache cacheQuery, Map<String, dynamic> substitutionValues) {
+  void sendCachedQuery(Socket socket, CachedQuery cacheQuery, Map<String, dynamic> substitutionValues) {
     var statementName = cacheQuery.preparedStatementName;
     var parameterList =
         cacheQuery.orderedParameters.map((identifier) => encodeParameter(identifier, substitutionValues)).toList();
@@ -145,8 +145,8 @@ class Query<T> {
   String toString() => statement;
 }
 
-class QueryCache {
-  QueryCache(this.preparedStatementName, this.orderedParameters);
+class CachedQuery {
+  CachedQuery(this.preparedStatementName, this.orderedParameters);
 
   String preparedStatementName;
   List<PostgreSQLFormatIdentifier> orderedParameters;

--- a/lib/src/query_cache.dart
+++ b/lib/src/query_cache.dart
@@ -1,0 +1,37 @@
+import 'package:postgres/src/query.dart';
+
+class QueryCache {
+  final Map<String, CachedQuery> queries = {};
+  int idCounter = 0;
+
+  void add(Query<dynamic> query) {
+    if (query.cache == null) {
+      return;
+    }
+
+    if (query.cache.isValid) {
+      queries[query.statement] = query.cache;
+    }
+  }
+
+  operator [](String statementId) {
+    if (statementId == null) {
+      return null;
+    }
+
+    return queries[statementId];
+  }
+
+  String identifierForQuery(Query<dynamic> query) {
+    var existing = queries[query.statement];
+    if (existing != null) {
+      return existing.preparedStatementName;
+    }
+
+    var string = "$idCounter".padLeft(12, "0");
+
+    idCounter++;
+
+    return string;
+  }
+}

--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -47,7 +47,7 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
         fmtString, substitutionValues, connection, this);
 
     if (allowReuse) {
-      query.statementIdentifier = connection._reuseIdentifierForQuery(query);
+      query.statementIdentifier = connection._cache.identifierForQuery(query);
     }
 
     return enqueue(query);
@@ -99,7 +99,7 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
     try {
       final result = await query.future;
 
-      connection._cacheQuery(query);
+      connection._cache.add(query);
       queryQueue.remove(query);
 
       return result;

--- a/test/query_reuse_test.dart
+++ b/test/query_reuse_test.dart
@@ -481,7 +481,7 @@ void main() {
     });
 
     test(
-        "A failed bind on initial query fails query, but cached query is available",
+        "A failed bind on initial query fails query, but can still make query later",
         () async {
       var string = "insert into u (i1, i2) values (@i1, @i2) returning i1, i2";
       try {
@@ -491,7 +491,7 @@ void main() {
         expect(true, false);
       } on PostgreSQLException {}
 
-      expect(hasCachedQueryNamed(connection, string), true);
+      expect(hasCachedQueryNamed(connection, string), false);
 
       var results = await connection.query("select i1, i2 from u");
       expect(results, []);
@@ -501,6 +501,7 @@ void main() {
       expect(results, [
         [1, 2]
       ]);
+      expect(hasCachedQueryNamed(connection, string), true);
     });
 
     test(
@@ -557,9 +558,9 @@ void main() {
 }
 
 Map<String, dynamic> cachedQueryMap(PostgreSQLConnection connection) {
-  var reuseMapMirror = reflect(connection).type.declarations.values.firstWhere(
-      (DeclarationMirror dm) => dm.simpleName.toString().contains("_reuseMap"));
-  return reflect(connection).getField(reuseMapMirror.simpleName).reflectee
+  var cacheMirror = reflect(connection).type.declarations.values.firstWhere(
+      (DeclarationMirror dm) => dm.simpleName.toString().contains("_cache"));
+  return reflect(connection).getField(cacheMirror.simpleName).getField(#queries).reflectee
       as Map<String, dynamic>;
 }
 


### PR DESCRIPTION
… object.

This is the first part of a refactor to unify the execution context/connection interface to avoid duplicate code paths.