### PR TITLE
Refactors connections and transactions to unify their behavior

### DIFF
--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -163,7 +163,7 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
   Completer openCompleter;
 
   _PostgreSQLConnectionState awake() {
-    var pendingQuery = connection._pendingQuery;
+    var pendingQuery = connection._queue.pending;
     if (pendingQuery != null) {
       return processQuery(pendingQuery);
     }
@@ -232,7 +232,7 @@ class _PostgreSQLConnectionStateBusy extends _PostgreSQLConnectionState {
     // We ignore NoData, as it doesn't tell us anything we don't already know
     // or care about.
 
-    //print("(${query.statement}) -> $message");
+    // print("(${query.statement}) -> $message");
 
     if (message is ReadyForQueryMessage) {
       if (message.state == ReadyForQueryMessage.StateTransactionError) {
@@ -282,7 +282,7 @@ class _PostgreSQLConnectionStateReadyInTransaction extends _PostgreSQLConnection
   }
 
   _PostgreSQLConnectionState awake() {
-    var pendingQuery = transaction.pendingQuery;
+    var pendingQuery = transaction._queue.pending;
     if (pendingQuery != null) {
       return processQuery(pendingQuery);
     }

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -298,6 +298,7 @@ class _PostgreSQLConnectionStateReadyInTransaction extends _PostgreSQLConnection
       }
 
       final cached = connection._cache[q.statement];
+      var cached = connection._cache[q.statement];
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -298,7 +298,6 @@ class _PostgreSQLConnectionStateReadyInTransaction extends _PostgreSQLConnection
       }
 
       final cached = connection._cache[q.statement];
-      var cached = connection._cache[q.statement];
       q.sendExtended(connection._socket, cacheQuery: cached);
 
       return new _PostgreSQLConnectionStateBusy(q);

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+abstract class PostgreSQLExecutionContext {
+  /// Executes a query on this context.
+  ///
+  /// This method sends the query described by [fmtString] to the database and returns a [Future] whose value is the returned rows from the query after the query completes.
+  /// The format string may contain parameters that are provided in [substitutionValues]. Parameters are prefixed with the '@' character. Keys to replace the parameters
+  /// do not include the '@' character. For example:
+  ///
+  ///         connection.query("SELECT * FROM table WHERE id = @idParam", {"idParam" : 2});
+  ///
+  /// The type of the value is inferred by default, but can be made more specific by adding ':type" to the parameter pattern in the format string. The possible values
+  /// are declared as static variables in [PostgreSQLCodec] (e.g., [PostgreSQLCodec.TypeInt4]). For example:
+  ///
+  ///         connection.query("SELECT * FROM table WHERE id = @idParam:int4", {"idParam" : 2});
+  ///
+  /// You may also use [PostgreSQLFormat.id] to create parameter patterns.
+  ///
+  /// If successful, the returned [Future] completes with a [List] of rows. Each is row is represented by a [List] of column values for that row that were returned by the query.
+  ///
+  /// By default, instances of this class will reuse queries. This allows significantly more efficient transport to and from the database. You do not have to do
+  /// anything to opt in to this behavior, this connection will track the necessary information required to reuse queries without intervention. (The [fmtString] is
+  /// the unique identifier to look up reuse information.) You can disable reuse by passing false for [allowReuse].
+  Future<List<List<dynamic>>> query(String fmtString,
+    {Map<String, dynamic> substitutionValues: null, bool allowReuse: true});
+
+  /// Executes a query on this context.
+  ///
+  /// This method sends a SQL string to the database this instance is connected to. Parameters can be provided in [fmtString], see [query] for more details.
+  ///
+  /// This method returns the number of rows affected and no additional information. This method uses the least efficient and less secure command
+  /// for executing queries in the PostgreSQL protocol; [query] is preferred for queries that will be executed more than once, will contain user input,
+  /// or return rows.
+  Future<int> execute(String fmtString, {Map<String, dynamic> substitutionValues: null});
+
+  /// Cancels a transaction on this context.
+  ///
+  /// If this context is an instance of [PostgreSQLConnection], this method has no effect. If the context is a transaction context (passed as the argument
+  /// to [PostgreSQLConnection.transaction]), this will rollback the transaction.
+  void cancelTransaction({String reason: null});
+
+  /// Executes a query on this connection and returns each row as a [Map].
+  ///
+  /// This method constructs and executes a query in the same way as [query], but returns each row as a [Map].
+  ///
+  /// (Note: this method will execute additional queries to resolve table names the first time a table is encountered. These table names are cached per instance of this type.)
+  ///
+  /// Each row map contains key-value pairs for every table in the query. The value is a [Map] that contains
+  /// key-value pairs for each column from that table. For example, consider
+  /// the following query:
+  ///
+  ///         SELECT employee.id, employee.name FROM employee;
+  ///
+  /// This method would return the following structure:
+  ///
+  ///         [
+  ///           {"employee" : {"name": "Bob", "id": 1}}
+  ///         ]
+  ///
+  /// The purpose of this nested structure is to disambiguate columns that have the same name in different tables. For example, consider a query with a SQL JOIN:
+  ///
+  ///         SELECT employee.id, employee.name, company.name FROM employee LEFT OUTER JOIN company ON employee.company_id=company.id;
+  ///
+  /// Each returned [Map] would contain `employee` and `company` keys. The `name` key would be present in both inner maps.
+  ///
+  ///       [
+  ///         {
+  ///           "employee": {"name": "Bob", "id": 1},
+  ///           "company: {"name": "stable|kernel"}
+  ///         }
+  ///       ]
+  Future<List<Map<String, Map<String, dynamic>>>> mappedResultsQuery(String fmtString,
+    {Map<String, dynamic> substitutionValues: null, bool allowReuse: true});
+}

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'package:postgres/src/execution_context.dart';
+
 import 'postgresql_codec.dart';
 import 'connection.dart';
 import 'dart:io';

--- a/lib/src/query_queue.dart
+++ b/lib/src/query_queue.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:postgres/postgres.dart';
+import 'package:postgres/src/query.dart';
+
+class QueryQueue extends ListBase<Query<dynamic>> implements List<Query<dynamic>> {
+  List<Query<dynamic>> _inner = [];
+
+  Query<dynamic> get pending {
+    if (_inner.isEmpty) {
+      return null;
+    }
+    return _inner.first;
+  }
+
+  void cancel([Object error, StackTrace stackTrace]) {
+    error ??= "Cancelled";
+    final existing = _inner;
+    _inner = [];
+
+    // We need to jump this to the next event so that the queries
+    // get the error and not the close message, since completeError is
+    // synchronous.
+    scheduleMicrotask(() {
+      var exception =
+          new PostgreSQLException("Connection closed or query cancelled (reason: $error).", stackTrace: stackTrace);
+      existing?.forEach((q) {
+        q.completeError(exception, stackTrace);
+      });
+    });
+  }
+
+  @override
+  set length(int newLength) {
+    _inner.length = newLength;
+  }
+
+  @override
+  Query operator [](int index) => _inner[index];
+
+  @override
+  int get length => _inner.length;
+
+  @override
+  void operator []=(int index, Query value) => _inner[index] = value;
+
+  @override
+  void add(Query element) {
+    _inner.add(element);
+  }
+
+  @override
+  void addAll(Iterable<Query> iterable) {
+    _inner.addAll(iterable);
+  }
+}

--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -1,16 +1,12 @@
 part of postgres.connection;
 
-typedef Future<dynamic> _TransactionQuerySignature(
-    PostgreSQLExecutionContext connection);
+typedef Future<dynamic> _TransactionQuerySignature(PostgreSQLExecutionContext connection);
 
 class _TransactionProxy implements PostgreSQLExecutionContext {
   _TransactionProxy(this.connection, this.executionBlock) {
-    beginQuery = new Query<int>("BEGIN", {}, connection, this)
-      ..onlyReturnAffectedRowCount = true;
+    beginQuery = new Query<int>("BEGIN", {}, connection, this)..onlyReturnAffectedRowCount = true;
 
-    beginQuery.future
-        .then(startTransaction)
-        .catchError(handleTransactionQueryError);
+    beginQuery.future.then(startTransaction).catchError(handleTransactionQueryError);
   }
 
   Query<dynamic> beginQuery;
@@ -36,16 +32,12 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
   }
 
   Future<List<List<dynamic>>> query(String fmtString,
-      {Map<String, dynamic> substitutionValues: null,
-      bool allowReuse: true}) async {
+      {Map<String, dynamic> substitutionValues: null, bool allowReuse: true}) async {
     if (connection.isClosed) {
-      throw new PostgreSQLException(
-          "Attempting to execute query, but connection is not open.");
+      throw new PostgreSQLException("Attempting to execute query, but connection is not open.");
     }
 
-    var query = new Query<List<List<dynamic>>>(
-        fmtString, substitutionValues, connection, this);
-
+    var query = new Query<List<List<dynamic>>>(fmtString, substitutionValues, connection, this);
     if (allowReuse) {
       query.statementIdentifier = connection._cache.identifierForQuery(query);
     }
@@ -53,15 +45,12 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
     return enqueue(query);
   }
 
-  Future<int> execute(String fmtString,
-      {Map<String, dynamic> substitutionValues: null}) async {
+  Future<int> execute(String fmtString, {Map<String, dynamic> substitutionValues: null}) async {
     if (connection.isClosed) {
-      throw new PostgreSQLException(
-          "Attempting to execute query, but connection is not open.");
+      throw new PostgreSQLException("Attempting to execute query, but connection is not open.");
     }
 
-    var query = new Query<int>(fmtString, substitutionValues, connection, this)
-      ..onlyReturnAffectedRowCount = true;
+    var query = new Query<int>(fmtString, substitutionValues, connection, this)..onlyReturnAffectedRowCount = true;
 
     return enqueue(query);
   }
@@ -89,8 +78,7 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
     completer.complete(result);
   }
 
-  Future handleTransactionQueryError(dynamic err) async {
-  }
+  Future handleTransactionQueryError(dynamic err) async {}
 
   Future<T> enqueue<T>(Query<T> query) async {
     queryQueue.add(query);

--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -2,11 +2,11 @@ part of postgres.connection;
 
 typedef Future<dynamic> _TransactionQuerySignature(PostgreSQLExecutionContext connection);
 
-class _TransactionProxy implements PostgreSQLExecutionContext {
-  _TransactionProxy(this.connection, this.executionBlock) {
-    beginQuery = new Query<int>("BEGIN", {}, connection, this)..onlyReturnAffectedRowCount = true;
+class _TransactionProxy extends Object with _PostgreSQLExecutionContextMixin implements PostgreSQLExecutionContext {
+  _TransactionProxy(this._connection, this.executionBlock) {
+    beginQuery = new Query<int>("BEGIN", {}, _connection, this)..onlyReturnAffectedRowCount = true;
 
-    beginQuery.future.then(startTransaction).catchError(handleTransactionQueryError);
+    beginQuery.future.then(startTransaction).catchError(_onBeginFailure);
   }
 
   Query<dynamic> beginQuery;
@@ -14,16 +14,9 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
 
   Future get future => completer.future;
 
-  Query<dynamic> get pendingQuery {
-    if (queryQueue.length > 0) {
-      return queryQueue.first;
-    }
+  final PostgreSQLConnection _connection;
+  PostgreSQLExecutionContext get _transaction => this;
 
-    return null;
-  }
-
-  List<Query<dynamic>> queryQueue = [];
-  PostgreSQLConnection connection;
   _TransactionQuerySignature executionBlock;
   bool _hasFailed = false;
 
@@ -31,40 +24,20 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
     await execute("COMMIT");
   }
 
-  Future<List<List<dynamic>>> query(String fmtString,
-      {Map<String, dynamic> substitutionValues: null, bool allowReuse: true}) async {
-    if (connection.isClosed) {
-      throw new PostgreSQLException("Attempting to execute query, but connection is not open.");
-    }
-
-    var query = new Query<List<List<dynamic>>>(fmtString, substitutionValues, connection, this);
-    if (allowReuse) {
-      query.statementIdentifier = connection._cache.identifierForQuery(query);
-    }
-
-    return enqueue(query);
-  }
-
-  Future<int> execute(String fmtString, {Map<String, dynamic> substitutionValues: null}) async {
-    if (connection.isClosed) {
-      throw new PostgreSQLException("Attempting to execute query, but connection is not open.");
-    }
-
-    var query = new Query<int>(fmtString, substitutionValues, connection, this)..onlyReturnAffectedRowCount = true;
-
-    return enqueue(query);
-  }
-
   void cancelTransaction({String reason: null}) {
     throw new _TransactionRollbackException(reason);
   }
 
-  Future startTransaction(dynamic beginResults) async {
+  Future startTransaction(dynamic _) async {
     var result;
     try {
       result = await executionBlock(this);
+
+      // Place another event in the queue so that any non-awaited futures
+      // in the executionBlock are given a chance to run
+      await new Future(() => null);
     } on _TransactionRollbackException catch (rollback) {
-      queryQueue = [];
+      _queue.clear();
       await execute("ROLLBACK");
       completer.complete(new PostgreSQLRollback._(rollback.reason));
       return;
@@ -73,37 +46,34 @@ class _TransactionProxy implements PostgreSQLExecutionContext {
       return;
     }
 
+    // If we have queries pending, we need to wait for them to complete
+    // before finishing !!!!
+    if (_queue.isNotEmpty) {
+      // ignore the error from this query if there is one, it'll pop up elsewhere
+      await _queue.last.future.catchError((_) {});
+    }
+
     await execute("COMMIT");
 
     completer.complete(result);
   }
 
-  Future handleTransactionQueryError(dynamic err) async {}
-
-  Future<T> enqueue<T>(Query<T> query) async {
-    queryQueue.add(query);
-    connection._transitionToState(connection._connectionState.awake());
-
-    try {
-      final result = await query.future;
-
-      connection._cache.add(query);
-      queryQueue.remove(query);
-
-      return result;
-    } catch (e, st) {
-      await _transactionFailed(e, st);
-      rethrow;
-    }
+  Future _onBeginFailure(dynamic err) async {
+    completer.completeError(err);
   }
 
   Future _transactionFailed(dynamic error, [StackTrace trace]) async {
     if (!_hasFailed) {
       _hasFailed = true;
-      queryQueue = [];
+      _queue.clear();
       await execute("ROLLBACK");
       completer.completeError(error, trace);
     }
+  }
+
+  @override
+  Future _onQueryError(Query query, dynamic error, [StackTrace trace]) async {
+    await _transactionFailed(error, trace);
   }
 }
 

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -13,8 +13,7 @@ void main() {
     });
 
     test("Connect with md5 auth required", () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "dart", password: "dart");
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "dart", password: "dart");
 
       await conn.open();
 
@@ -22,67 +21,63 @@ void main() {
     });
 
     test("SSL Connect with md5 auth required", () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "dart", password: "dart", useSSL: true);
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "dart", password: "dart", useSSL: true);
 
       await conn.open();
 
       expect(await conn.execute("select 1"), equals(1));
-      var socketMirror = reflect(conn).type.declarations.values.firstWhere(
-          (DeclarationMirror dm) =>
-              dm.simpleName.toString().contains("_socket"));
-      var underlyingSocket =
-          reflect(conn).getField(socketMirror.simpleName).reflectee;
+      var socketMirror = reflect(conn)
+          .type
+          .declarations
+          .values
+          .firstWhere((DeclarationMirror dm) => dm.simpleName.toString().contains("_socket"));
+      var underlyingSocket = reflect(conn).getField(socketMirror.simpleName).reflectee;
       expect(underlyingSocket is SecureSocket, true);
     });
 
     test("Connect with no auth required", () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       expect(await conn.execute("select 1"), equals(1));
     });
 
     test("SSL Connect with no auth required", () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust", useSSL: true);
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust", useSSL: true);
       await conn.open();
 
       expect(await conn.execute("select 1"), equals(1));
     });
 
-    test("Closing idle connection succeeds, closes underlying socket",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+    test("Closing idle connection succeeds, closes underlying socket", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       await conn.close();
 
-      var socketMirror = reflect(conn).type.declarations.values.firstWhere(
-          (DeclarationMirror dm) =>
-              dm.simpleName.toString().contains("_socket"));
-      Socket underlyingSocket =
-          reflect(conn).getField(socketMirror.simpleName).reflectee;
+      var socketMirror = reflect(conn)
+          .type
+          .declarations
+          .values
+          .firstWhere((DeclarationMirror dm) => dm.simpleName.toString().contains("_socket"));
+      Socket underlyingSocket = reflect(conn).getField(socketMirror.simpleName).reflectee;
       expect(await underlyingSocket.done, isNotNull);
 
       conn = null;
     });
 
-    test("SSL Closing idle connection succeeds, closes underlying socket",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust", useSSL: true);
+    test("SSL Closing idle connection succeeds, closes underlying socket", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust", useSSL: true);
       await conn.open();
 
       await conn.close();
 
-      var socketMirror = reflect(conn).type.declarations.values.firstWhere(
-          (DeclarationMirror dm) =>
-              dm.simpleName.toString().contains("_socket"));
-      Socket underlyingSocket =
-          reflect(conn).getField(socketMirror.simpleName).reflectee;
+      var socketMirror = reflect(conn)
+          .type
+          .declarations
+          .values
+          .firstWhere((DeclarationMirror dm) => dm.simpleName.toString().contains("_socket"));
+      Socket underlyingSocket = reflect(conn).getField(socketMirror.simpleName).reflectee;
       expect(await underlyingSocket.done, isNotNull);
 
       conn = null;
@@ -91,8 +86,7 @@ void main() {
     test(
         "Closing connection while busy succeeds, queued queries are all accounted for (canceled), closes underlying socket",
         () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       var errors = [];
@@ -113,8 +107,7 @@ void main() {
     test(
         "SSL Closing connection while busy succeeds, queued queries are all accounted for (canceled), closes underlying socket",
         () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust", useSSL: true);
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust", useSSL: true);
       await conn.open();
 
       var errors = [];
@@ -137,8 +130,7 @@ void main() {
     PostgreSQLConnection conn = null;
 
     setUp(() async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
     });
 
@@ -146,9 +138,7 @@ void main() {
       await conn?.close();
     });
 
-    test(
-        "Issuing multiple queries and awaiting between each one successfully returns the right value",
-        () async {
+    test("Issuing multiple queries and awaiting between each one successfully returns the right value", () async {
       expect(
           await conn.query("select 1", allowReuse: false),
           equals([
@@ -176,9 +166,7 @@ void main() {
           ]));
     });
 
-    test(
-        "Issuing multiple queries without awaiting are returned with appropriate values",
-        () async {
+    test("Issuing multiple queries without awaiting are returned with appropriate values", () async {
       var futures = [
         conn.query("select 1", allowReuse: false),
         conn.query("select 2", allowReuse: false),
@@ -217,8 +205,7 @@ void main() {
     });
 
     test("Sending queries to opening connection triggers error", () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       conn.open();
 
       try {
@@ -230,8 +217,7 @@ void main() {
     });
 
     test("SSL Sending queries to opening connection triggers error", () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust", useSSL: true);
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust", useSSL: true);
       conn.open();
 
       try {
@@ -242,10 +228,8 @@ void main() {
       }
     });
 
-    test("Starting transaction while opening connection triggers error",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+    test("Starting transaction while opening connection triggers error", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       conn.open();
 
       try {
@@ -258,10 +242,8 @@ void main() {
       }
     });
 
-    test("SSL Starting transaction while opening connection triggers error",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust", useSSL: true);
+    test("SSL Starting transaction while opening connection triggers error", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust", useSSL: true);
       conn.open();
 
       try {
@@ -274,10 +256,8 @@ void main() {
       }
     });
 
-    test("Invalid password reports error, conn is closed, disables conn",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "dart", password: "notdart");
+    test("Invalid password reports error, conn is closed, disables conn", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "dart", password: "notdart");
 
       try {
         await conn.open();
@@ -289,10 +269,9 @@ void main() {
       await expectConnectionIsInvalid(conn);
     });
 
-    test("SSL Invalid password reports error, conn is closed, disables conn",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "dart", password: "notdart", useSSL: true);
+    test("SSL Invalid password reports error, conn is closed, disables conn", () async {
+      conn =
+          new PostgreSQLConnection("localhost", 5432, "dart_test", username: "dart", password: "notdart", useSSL: true);
 
       try {
         await conn.open();
@@ -304,10 +283,8 @@ void main() {
       await expectConnectionIsInvalid(conn);
     });
 
-    test("A query error maintains connectivity, allows future queries",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+    test("A query error maintains connectivity, allows future queries", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       await conn.execute("CREATE TEMPORARY TABLE t (i int unique)");
@@ -322,16 +299,14 @@ void main() {
       await conn.execute("INSERT INTO t (i) VALUES (2)");
     });
 
-    test(
-        "A query error maintains connectivity, continues processing pending queries",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+    test("A query error maintains connectivity, continues processing pending queries", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       await conn.execute("CREATE TEMPORARY TABLE t (i int unique)");
 
       await conn.execute("INSERT INTO t (i) VALUES (1)");
+      //ignore: unawaited_futures
       conn.execute("INSERT INTO t (i) VALUES (1)").catchError((err) {
         // ignore
       });
@@ -355,25 +330,26 @@ void main() {
         ]
       ]);
 
-      var queueMirror = reflect(conn).type.declarations.values.firstWhere(
-          (DeclarationMirror dm) =>
-              dm.simpleName.toString().contains("_queryQueue"));
-      List<dynamic> queue =
-          reflect(conn).getField(queueMirror.simpleName).reflectee;
+      var queueMirror = reflect(conn)
+          .type
+          .instanceMembers
+          .values
+          .firstWhere((DeclarationMirror dm) => dm.simpleName.toString().contains("_queue"));
+      List<dynamic> queue = reflect(conn).getField(queueMirror.simpleName).reflectee;
       expect(queue, isEmpty);
     });
 
-    test(
-        "A query error maintains connectivity, continues processing pending transactions",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+    test("A query error maintains connectivity, continues processing pending transactions", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       await conn.execute("CREATE TEMPORARY TABLE t (i int unique)");
       await conn.execute("INSERT INTO t (i) VALUES (1)");
 
-      var orderEnsurer = [];
+      final orderEnsurer = [];
+
+      // this will emit a query error
+      //ignore: unawaited_futures
       conn.execute("INSERT INTO t (i) VALUES (1)").catchError((err) {
         orderEnsurer.add(1);
         // ignore
@@ -392,11 +368,8 @@ void main() {
       expect(orderEnsurer, [2, 1, 3, 4]);
     });
 
-    test(
-        "Building query throws error, connection continues processing pending queries",
-        () async {
-      conn = new PostgreSQLConnection("localhost", 5432, "dart_test",
-          username: "darttrust");
+    test("Building query throws error, connection continues processing pending queries", () async {
+      conn = new PostgreSQLConnection("localhost", 5432, "dart_test", username: "darttrust");
       await conn.open();
 
       // Make some async queries that'll exit the event loop, but then fail on a query that'll die early
@@ -419,11 +392,12 @@ void main() {
         ]
       ]);
 
-      var queueMirror = reflect(conn).type.declarations.values.firstWhere(
-          (DeclarationMirror dm) =>
-              dm.simpleName.toString().contains("_queryQueue"));
-      List<dynamic> queue =
-          reflect(conn).getField(queueMirror.simpleName).reflectee;
+      var queueMirror = reflect(conn)
+          .type
+          .instanceMembers
+          .values
+          .firstWhere((DeclarationMirror dm) => dm.simpleName.toString().contains("_queue"));
+      List<dynamic> queue = reflect(conn).getField(queueMirror.simpleName).reflectee;
       expect(queue, isEmpty);
     });
   });
@@ -437,9 +411,7 @@ void main() {
       await socket?.close();
     });
 
-    test(
-        "Socket fails to connect reports error, disables connection for future use",
-        () async {
+    test("Socket fails to connect reports error, disables connection for future use", () async {
       var conn = new PostgreSQLConnection("localhost", 5431, "dart_test");
 
       try {
@@ -450,11 +422,8 @@ void main() {
       await expectConnectionIsInvalid(conn);
     });
 
-    test(
-        "SSL Socket fails to connect reports error, disables connection for future use",
-        () async {
-      var conn = new PostgreSQLConnection("localhost", 5431, "dart_test",
-          useSSL: true);
+    test("SSL Socket fails to connect reports error, disables connection for future use", () async {
+      var conn = new PostgreSQLConnection("localhost", 5431, "dart_test", useSSL: true);
 
       try {
         await conn.open();
@@ -464,19 +433,15 @@ void main() {
       await expectConnectionIsInvalid(conn);
     });
 
-    test(
-        "Connection that times out throws appropriate error and cannot be reused",
-        () async {
-      serverSocket =
-          await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
+    test("Connection that times out throws appropriate error and cannot be reused", () async {
+      serverSocket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
       serverSocket.listen((s) {
         socket = s;
         // Don't respond on purpose
         s.listen((bytes) {});
       });
 
-      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test",
-          timeoutInSeconds: 2);
+      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test", timeoutInSeconds: 2);
 
       try {
         await conn.open();
@@ -487,19 +452,15 @@ void main() {
       await expectConnectionIsInvalid(conn);
     });
 
-    test(
-        "SSL Connection that times out throws appropriate error and cannot be reused",
-        () async {
-      serverSocket =
-          await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
+    test("SSL Connection that times out throws appropriate error and cannot be reused", () async {
+      serverSocket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
       serverSocket.listen((s) {
         socket = s;
         // Don't respond on purpose
         s.listen((bytes) {});
       });
 
-      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test",
-          timeoutInSeconds: 2, useSSL: true);
+      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test", timeoutInSeconds: 2, useSSL: true);
 
       try {
         await conn.open();
@@ -510,11 +471,9 @@ void main() {
       await expectConnectionIsInvalid(conn);
     });
 
-    test("Connection that times out triggers future for pending queries",
-        () async {
+    test("Connection that times out triggers future for pending queries", () async {
       var openCompleter = new Completer();
-      serverSocket =
-          await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
+      serverSocket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
       serverSocket.listen((s) {
         socket = s;
         // Don't respond on purpose
@@ -524,8 +483,7 @@ void main() {
         });
       });
 
-      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test",
-          timeoutInSeconds: 2);
+      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test", timeoutInSeconds: 2);
       conn.open().catchError((e) {});
 
       await openCompleter.future;
@@ -538,11 +496,9 @@ void main() {
       }
     });
 
-    test("SSL Connection that times out triggers future for pending queries",
-        () async {
+    test("SSL Connection that times out triggers future for pending queries", () async {
       var openCompleter = new Completer();
-      serverSocket =
-          await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
+      serverSocket = await ServerSocket.bind(InternetAddress.LOOPBACK_IP_V4, 5433);
       serverSocket.listen((s) {
         socket = s;
         // Don't respond on purpose
@@ -552,8 +508,7 @@ void main() {
         });
       });
 
-      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test",
-          timeoutInSeconds: 2, useSSL: true);
+      var conn = new PostgreSQLConnection("localhost", 5433, "dart_test", timeoutInSeconds: 2, useSSL: true);
       conn.open().catchError((e) {});
 
       await openCompleter.future;

--- a/test/query_reuse_test.dart
+++ b/test/query_reuse_test.dart
@@ -542,6 +542,7 @@ void main() {
           allowReuse: false);
 
       var string = "select i1, i2 from u where i1 = @i:int4";
+      // ignore: unawaited_futures
       connection
           .query(string, substitutionValues: {"i": "foo"}).catchError((e) {});
 


### PR DESCRIPTION
Avoids having multiple code paths for queries executes in a transaction vs. not. Adds a few more tests around transactions.