### PR TITLE
A few cleanup items 

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -3,3 +3,4 @@ library postgres;
 export 'src/connection.dart';
 export 'src/types.dart';
 export 'src/substituter.dart';
+export 'src/execution_context.dart';

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'dart:typed_data';
 
+import 'package:dart2_constant/convert.dart' as _convert;
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/types.dart';
 
@@ -269,7 +270,15 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
         }
     }
 
-    return value;
+    // We'll try and decode this as a utf8 string and return that
+    // for many internal types, this is valid. If it fails,
+    // we just return the bytes and let the caller figure out what to
+    // do with it.
+    try {
+      return _convert.utf8.decode(value);
+    } catch (_) {
+      return value;
+    }
   }
 
   static final Map<int, PostgreSQLDataType> typeMap = {

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -63,6 +63,7 @@ class PostgresBinaryEncoder extends Converter<dynamic, Uint8List> {
         bd.setInt16(0, value);
         return bd.buffer.asUint8List();
       }
+      case PostgreSQLDataType.name:
       case PostgreSQLDataType.text: {
         if (value is! String) {
           throw new FormatException(
@@ -173,6 +174,7 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
     final buffer = new ByteData.view(value.buffer, value.offsetInBytes, value.lengthInBytes);
 
     switch (dataType) {
+      case PostgreSQLDataType.name:
       case PostgreSQLDataType.text:
         return UTF8.decode(value.buffer.asUint8List(value.offsetInBytes, value.lengthInBytes));
       case PostgreSQLDataType.boolean:
@@ -206,6 +208,8 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
 
       case PostgreSQLDataType.byteArray:
         return value.buffer.asUint8List(value.offsetInBytes, value.lengthInBytes);
+
+
     }
 
     return value;
@@ -214,6 +218,7 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
   static final Map<int, PostgreSQLDataType> typeMap = {
     16: PostgreSQLDataType.boolean,
     17: PostgreSQLDataType.byteArray,
+    19: PostgreSQLDataType.name,
     20: PostgreSQLDataType.bigInteger,
     21: PostgreSQLDataType.smallInteger,
     23: PostgreSQLDataType.integer,
@@ -223,6 +228,7 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
     1082: PostgreSQLDataType.date,
     1114: PostgreSQLDataType.timestampWithoutTimezone,
     1184: PostgreSQLDataType.timestampWithTimezone,
-    3802: PostgreSQLDataType.json
+    3802: PostgreSQLDataType.json,
+
   };
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -81,7 +81,7 @@ class PostgreSQLConnection extends Object with _PostgreSQLExecutionContextMixin 
 
   /// Whether or not this connection is open or not.
   ///
-  /// This is [true] when this instance is first created and after it has been closed or encountered an unrecoverable error.
+  /// This is `true` when this instance is first created and after it has been closed or encountered an unrecoverable error.
   /// If a connection has already been opened and this value is now true, the connection cannot be reopened and a new instance
   /// must be created.
   bool get isClosed => _connectionState is _PostgreSQLConnectionStateClosed;

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -408,7 +408,7 @@ abstract class _PostgreSQLExecutionContextMixin implements PostgreSQLExecutionCo
     orderedTableNames.forEach((tableName) {
       iterator.moveNext();
       if (tableName.first != null) {
-        _tableOIDNameMap[iterator.current] = convert.utf8.decode(tableName.first);
+        _tableOIDNameMap[iterator.current] = tableName.first;
       }
     });
   }

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -1,4 +1,8 @@
 import 'dart:async';
+import 'query.dart';
+import 'types.dart';
+import 'substituter.dart';
+import 'connection.dart';
 
 abstract class PostgreSQLExecutionContext {
   /// Executes a query on this context.
@@ -9,12 +13,12 @@ abstract class PostgreSQLExecutionContext {
   ///
   ///         connection.query("SELECT * FROM table WHERE id = @idParam", {"idParam" : 2});
   ///
-  /// The type of the value is inferred by default, but can be made more specific by adding ':type" to the parameter pattern in the format string. The possible values
-  /// are declared as static variables in [PostgreSQLCodec] (e.g., [PostgreSQLCodec.TypeInt4]). For example:
+  /// The type of the value is inferred by default, but should be made more specific by adding ':type" to the parameter pattern in the format string. For example:
   ///
   ///         connection.query("SELECT * FROM table WHERE id = @idParam:int4", {"idParam" : 2});
   ///
-  /// You may also use [PostgreSQLFormat.id] to create parameter patterns.
+  /// Available types are listed in [PostgreSQLFormatIdentifier.typeStringToCodeMap]. Some types have multiple options. It is preferable to use the [PostgreSQLFormat.id]
+  /// function to add parameters to a query string. This method inserts a parameter name and the appropriate ':type' string for a [PostgreSQLDataType].
   ///
   /// If successful, the returned [Future] completes with a [List] of rows. Each is row is represented by a [List] of column values for that row that were returned by the query.
   ///

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -266,7 +266,8 @@ class PostgreSQLFormatIdentifier {
     "timestamp": PostgreSQLDataType.timestampWithoutTimezone,
     "timestamptz": PostgreSQLDataType.timestampWithTimezone,
     "jsonb": PostgreSQLDataType.json,
-    "bytea": PostgreSQLDataType.byteArray
+    "bytea": PostgreSQLDataType.byteArray,
+    "name": PostgreSQLDataType.name
   };
 
   PostgreSQLFormatIdentifier(String t) {

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -254,8 +254,6 @@ class PostgreSQLFormatToken {
 class PostgreSQLFormatIdentifier {
   static Map<String, PostgreSQLDataType> typeStringToCodeMap = {
     "text": PostgreSQLDataType.text,
-    "serial": PostgreSQLDataType.serial,
-    "bigserial": PostgreSQLDataType.bigSerial,
     "int2": PostgreSQLDataType.smallInteger,
     "int4": PostgreSQLDataType.integer,
     "int8": PostgreSQLDataType.bigInteger,

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -24,9 +24,9 @@ class PostgreSQLFormat {
       case PostgreSQLDataType.bigInteger:
         return "int8";
       case PostgreSQLDataType.serial:
-        return "int4";
+        return "serial";
       case PostgreSQLDataType.bigSerial:
-        return "int8";
+        return "bigserial";
       case PostgreSQLDataType.real:
         return "float4";
       case PostgreSQLDataType.double:
@@ -43,6 +43,8 @@ class PostgreSQLFormat {
         return "jsonb";
       case PostgreSQLDataType.byteArray:
         return "bytea";
+      case PostgreSQLDataType.name:
+        return "name";
     }
 
     return null;

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -24,9 +24,9 @@ class PostgreSQLFormat {
       case PostgreSQLDataType.bigInteger:
         return "int8";
       case PostgreSQLDataType.serial:
-        return "serial";
+        return "int4";
       case PostgreSQLDataType.bigSerial:
-        return "bigserial";
+        return "int8";
       case PostgreSQLDataType.real:
         return "float4";
       case PostgreSQLDataType.double:

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -55,5 +55,10 @@ enum PostgreSQLDataType {
   /// Must be a [List] of [int].
   ///
   /// Each element of the list must fit into a byte (0-255).
-  byteArray
+  byteArray,
+
+  /// Must be a [String]
+  ///
+  /// Used for internal pg structure names
+  name
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -52,7 +52,7 @@ enum PostgreSQLDataType {
   /// Values will be encoded via [JSON.encode] before being sent to the database.
   json,
 
-  /// Must be a [List<int>].
+  /// Must be a [List] of [int].
   ///
   /// Each element of the list must fit into a byte (0-255).
   byteArray

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -128,6 +128,4 @@ void main() {
       [null]
     ]);
   });
-
-  test("Timezone concerns", () {});
 }

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -68,7 +68,7 @@ void main() {
       await expectInverse(0, PostgreSQLDataType.serial);
       await expectInverse(1, PostgreSQLDataType.serial);
       try {
-        await conn.query("INSERT INTO t (v) VALUES (@v:serial)", substitutionValues: {"v": "not-serial"});
+        await conn.query("INSERT INTO t (v) VALUES (@v:int4)", substitutionValues: {"v": "not-serial"});
         fail('unreachable');
       } on FormatException catch (e) {
         expect(e.toString(), contains("Expected: int"));
@@ -93,7 +93,7 @@ void main() {
       await expectInverse(0, PostgreSQLDataType.bigSerial);
       await expectInverse(1, PostgreSQLDataType.bigSerial);
       try {
-        await conn.query("INSERT INTO t (v) VALUES (@v:bigserial)", substitutionValues: {"v": "not-bigserial"});
+        await conn.query("INSERT INTO t (v) VALUES (@v:int8)", substitutionValues: {"v": "not-bigserial"});
         fail('unreachable');
       } on FormatException catch (e) {
         expect(e.toString(), contains("Expected: int"));

--- a/test/interpolation_test.dart
+++ b/test/interpolation_test.dart
@@ -7,11 +7,19 @@ import 'package:test/test.dart';
 
 void main() {
   test("Ensure all types/format type mappings are available and accurate", () {
-    PostgreSQLDataType.values.forEach((t) {
+    PostgreSQLDataType.values.where((t) => t != PostgreSQLDataType.bigSerial && t != PostgreSQLDataType.serial).forEach((t) {
       expect(PostgreSQLFormatIdentifier.typeStringToCodeMap.values.contains(t), true);
       final code = PostgreSQLFormat.dataTypeStringForDataType(t); 
       expect(PostgreSQLFormatIdentifier.typeStringToCodeMap[code], t);
     });
+  });
+
+  test("Ensure bigserial gets translated to int8", () {
+    expect(PostgreSQLFormat.dataTypeStringForDataType(PostgreSQLDataType.serial), "int4");
+  });
+
+  test("Ensure serial gets translated to int4", () {
+    expect(PostgreSQLFormat.dataTypeStringForDataType(PostgreSQLDataType.bigSerial), "int8");
   });
 
   test("Simple replacement", () {

--- a/test/interpolation_test.dart
+++ b/test/interpolation_test.dart
@@ -1,9 +1,19 @@
 import 'package:dart2_constant/convert.dart' as convert;
+
+import 'package:postgres/postgres.dart';
+import 'package:postgres/src/query.dart';
 import 'package:test/test.dart';
 
-import 'package:postgres/src/substituter.dart';
 
 void main() {
+  test("Ensure all types/format type mappings are available and accurate", () {
+    PostgreSQLDataType.values.forEach((t) {
+      expect(PostgreSQLFormatIdentifier.typeStringToCodeMap.values.contains(t), true);
+      final code = PostgreSQLFormat.dataTypeStringForDataType(t); 
+      expect(PostgreSQLFormatIdentifier.typeStringToCodeMap[code], t);
+    });
+  });
+
   test("Simple replacement", () {
     var result = PostgreSQLFormat.substitute("@id", {"id": 20});
     expect(result, equals("20"));


### PR DESCRIPTION
- Exports execution context. This was hidden to consumer libraries during a previous PR.
- Adds support for `name` column type
- Improves API ref for recent changes
- Adds some new tests to ensure new types are added correctly.
