### PR TITLE
Export execution context.

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -1,5 +1,6 @@
 library postgres;
 
 export 'src/connection.dart';
+export 'src/execution_context.dart';
 export 'src/types.dart';
 export 'src/substituter.dart';


### PR DESCRIPTION
The connection.transaction method uses that, needs to be exported for client-library use.