### PR TITLE
Better oid->relname resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1-dev
+
+- Better `oid`->`relname` resolution.
+
 ## 1.0.0
 
 - Adds support for Dart 2

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -379,11 +379,11 @@ abstract class _PostgreSQLExecutionContextMixin implements PostgreSQLExecutionCo
   }
 
   Future _resolveTableOIDs(List<int> oids) async {
+    final unresolvedOids = oids.toSet();
     final unresolvedIDString = oids.join(",");
     final orderedTableNames = await query(
         "SELECT oid, relname FROM pg_class WHERE relkind='r' AND oid IN ($unresolvedIDString) ORDER BY oid ASC");
 
-    final unresolvedOids = oids.toSet();
     for (List list in orderedTableNames) {
       final int oid = list[0];
       final String name = list[1];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 1.0.0
+version: 1.0.1-dev
 author: stable|kernel <jobs@stablekernel.com>
 homepage: https://github.com/stablekernel/postgresql-dart
 documentation:


### PR DESCRIPTION
I've found that on CockroachDB the driver executes many relname request, for the oid=0. Instead of handling that specific use case, I've decided to make the resolution a bit more robust (e.g. handling the edge case where the lookup of the oids succeeds only partially).