### PR TITLE
Restricted field access on PostgreSQLConnection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- Restricted field access on [PostgreSQLConnection].
+
 ## 1.0.2
 - Add connection queue size
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -43,31 +43,31 @@ class PostgreSQLConnection extends Object with _PostgreSQLExecutionContextMixin 
   final StreamController<Notification> _notifications = new StreamController<Notification>.broadcast();
 
   /// Hostname of database this connection refers to.
-  String host;
+  final String host;
 
   /// Port of database this connection refers to.
-  int port;
+  final int port;
 
   /// Name of database this connection refers to.
-  String databaseName;
+  final String databaseName;
 
   /// Username for authenticating this connection.
-  String username;
+  final String username;
 
   /// Password for authenticating this connection.
-  String password;
+  final String password;
 
   /// Whether or not this connection should connect securely.
-  bool useSSL;
+  final bool useSSL;
 
   /// The amount of time this connection will wait during connecting before giving up.
-  int timeoutInSeconds;
+  final int timeoutInSeconds;
 
   /// The timezone of this connection for date operations that don't specify a timezone.
-  String timeZone;
+  final String timeZone;
 
   /// The processID of this backend.
-  int processID;
+  int get processID => _processID;
 
   /// Stream of notification from the database.
   ///
@@ -88,11 +88,12 @@ class PostgreSQLConnection extends Object with _PostgreSQLExecutionContextMixin 
   ///
   /// After connecting to a database, this map will contain the settings values that the database returns.
   /// Prior to connection, it is the empty map.
-  Map<String, String> settings = {};
+  final Map<String, String> settings = {};
 
   QueryCache _cache = new QueryCache();
   Socket _socket;
   MessageFramer _framer = new MessageFramer();
+  int _processID;
   int _secretKey;
   List<int> _salt;
 

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -108,8 +108,8 @@ class _PostgreSQLConnectionStateAuthenticating extends _PostgreSQLConnectionStat
     if (message is ParameterStatusMessage) {
       connection.settings[message.name] = message.value;
     } else if (message is BackendKeyMessage) {
+      connection._processID = message.processID;
       connection._secretKey = message.secretKey;
-      connection.processID = message.processID;
     } else if (message is ReadyForQueryMessage) {
       if (message.state == ReadyForQueryMessage.StateIdle) {
         return new _PostgreSQLConnectionStateIdle(openCompleter: completer);
@@ -141,8 +141,8 @@ class _PostgreSQLConnectionStateAuthenticated extends _PostgreSQLConnectionState
     if (message is ParameterStatusMessage) {
       connection.settings[message.name] = message.value;
     } else if (message is BackendKeyMessage) {
+      connection._processID = message.processID;
       connection._secretKey = message.secretKey;
-      connection.processID = message.processID;
     } else if (message is ReadyForQueryMessage) {
       if (message.state == ReadyForQueryMessage.StateIdle) {
         return new _PostgreSQLConnectionStateIdle(openCompleter: completer);


### PR DESCRIPTION
I believe these fields should not be settable by the client app that is connecting to a database. It also helps with dealing with mock interfaces and delegates.