### PR TITLE
Connection-level default query timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.3
 
 - Restricted field access on [PostgreSQLConnection].
+- Connection-level default query timeout.
 
 ## 1.0.2
 - Add connection queue size


### PR DESCRIPTION
I believe this shouldn't change any behaviour. One extra benefit will be that proxy objects that wrap `PostgreSQLExecutionContext` can keep the same undefined timeout as the interface provides, and don't need to worry if they pass a null object in.