### PR TITLE
Missing substitution value no longer throws FormatException.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+
+- Missing substitution value no longer throws `FormatException`.
+  [More details in the GitHub issue.](https://github.com/stablekernel/postgresql-dart/issues/57)
+
 ## 2.0.0
 
 - Fixed startup packet length when username is null (#111).

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -119,8 +119,9 @@ class PostgreSQLFormat {
         final identifier = PostgreSQLFormatIdentifier(t.buffer.toString());
 
         if (!values.containsKey(identifier.name)) {
-          throw FormatException(
-              'Format string specified identifier with name ${identifier.name}, but key was not present in values. Format string: $fmtString');
+          // Format string specified identifier with name ${identifier.name},
+          // but key was not present in values.
+          return t.buffer;
         }
 
         final val = replace(identifier, idx);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.0.0
+version: 2.1.0
 author: stable|kernel <jobs@stablekernel.com>
 homepage: https://github.com/stablekernel/postgresql-dart
 documentation:

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -361,24 +361,25 @@ void main() {
     });
 
     test(
-        'Not enough parameters to support format string throws error prior to sending to server',
+        'Missing substitution value does not throw, query is sent to the server without changing that part.',
         () async {
-      try {
-        await connection
-            .query('INSERT INTO t (i1) values (@i1)', substitutionValues: {});
-        expect(true, false);
-      } on FormatException catch (e) {
-        expect(e.message,
-            contains('Format string specified identifier with name i1'));
-      }
+      final rs1 = await connection
+          .query('SELECT *  FROM (VALUES (\'user@domain.com\')) t1 (col1)');
+      expect(rs1.first.toTableColumnMap(), {
+        't1': {
+          'col1': 'user@domain.com',
+        },
+      });
 
-      try {
-        await connection.query('INSERT INTO t (i1) values (@i1)');
-        expect(true, false);
-      } on FormatException catch (e) {
-        expect(e.message,
-            contains('Format string specified identifier with name i1'));
-      }
+      final rs2 = await connection.query(
+        'SELECT *  FROM (VALUES (\'user@domain.com\')) t1 (col1) WHERE col1 > @u1',
+        substitutionValues: {'u1': 'hello@domain.com'},
+      );
+      expect(rs2.first.toTableColumnMap(), {
+        't1': {
+          'col1': 'user@domain.com',
+        },
+      });
     });
 
     test('Wrong type for parameter in substitution values fails', () async {

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -365,21 +365,13 @@ void main() {
         () async {
       final rs1 = await connection
           .query('SELECT *  FROM (VALUES (\'user@domain.com\')) t1 (col1)');
-      expect(rs1.first.toTableColumnMap(), {
-        't1': {
-          'col1': 'user@domain.com',
-        },
-      });
+      expect(rs1.first.toColumnMap(), {'col1': 'user@domain.com'});
 
       final rs2 = await connection.query(
         'SELECT *  FROM (VALUES (\'user@domain.com\')) t1 (col1) WHERE col1 > @u1',
         substitutionValues: {'u1': 'hello@domain.com'},
       );
-      expect(rs2.first.toTableColumnMap(), {
-        't1': {
-          'col1': 'user@domain.com',
-        },
-      });
+      expect(rs2.first.toColumnMap(), {'col1': 'user@domain.com'});
     });
 
     test('Wrong type for parameter in substitution values fails', () async {


### PR DESCRIPTION
Fixes #57.