### PR TITLE
Added rowsAffected to PostgreSQLResult

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -444,7 +444,8 @@ abstract class _PostgreSQLExecutionContextMixin
       query.statementIdentifier = _connection._cache.identifierForQuery(query);
     }
 
-    final queryResult = await _enqueue(query, timeoutInSeconds: timeoutInSeconds);
+    final queryResult =
+        await _enqueue(query, timeoutInSeconds: timeoutInSeconds);
     var columnDescriptions = query.fieldDescriptions;
     if (resolveOids) {
       columnDescriptions = await _connection._oidCache
@@ -477,7 +478,7 @@ abstract class _PostgreSQLExecutionContextMixin
 
   @override
   Future<int> execute(String fmtString,
-      {Map<String, dynamic> substitutionValues, int timeoutInSeconds}) {
+      {Map<String, dynamic> substitutionValues, int timeoutInSeconds}) async {
     timeoutInSeconds ??= _connection.queryTimeoutInSeconds;
     if (_connection.isClosed) {
       throw PostgreSQLException(
@@ -488,13 +489,15 @@ abstract class _PostgreSQLExecutionContextMixin
         fmtString, substitutionValues, _connection, _transaction,
         onlyReturnAffectedRowCount: true);
 
-    return _enqueue(query, timeoutInSeconds: timeoutInSeconds).then((result) => result.affectedRowCount);
+    final result = await _enqueue(query, timeoutInSeconds: timeoutInSeconds);
+    return result.affectedRowCount;
   }
 
   @override
   void cancelTransaction({String reason});
 
-  Future<QueryResult<T>> _enqueue<T>(Query<T> query, {int timeoutInSeconds = 30}) async {
+  Future<QueryResult<T>> _enqueue<T>(Query<T> query,
+      {int timeoutInSeconds = 30}) async {
     if (_queue.add(query)) {
       _connection._transitionToState(_connection._connectionState.awake());
 
@@ -540,7 +543,8 @@ class _PostgreSQLResult extends UnmodifiableListView<PostgreSQLResultRow>
   final int affectedRowCount;
   final _PostgreSQLResultMetaData _metaData;
 
-  _PostgreSQLResult(this.affectedRowCount, this._metaData, List<PostgreSQLResultRow> rows)
+  _PostgreSQLResult(
+      this.affectedRowCount, this._metaData, List<PostgreSQLResultRow> rows)
       : super(rows);
 
   @override

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -453,7 +453,7 @@ abstract class _PostgreSQLExecutionContextMixin
     final metaData = _PostgreSQLResultMetaData(columnDescriptions);
 
     return _PostgreSQLResult(
-        queryResult.rowsAffected,
+        queryResult.affectedRowCount,
         metaData,
         queryResult.value
             .map((columns) => _PostgreSQLResultRow(metaData, columns))
@@ -488,7 +488,7 @@ abstract class _PostgreSQLExecutionContextMixin
         fmtString, substitutionValues, _connection, _transaction,
         onlyReturnAffectedRowCount: true);
 
-    return _enqueue(query, timeoutInSeconds: timeoutInSeconds).then((result) => result.rowsAffected);
+    return _enqueue(query, timeoutInSeconds: timeoutInSeconds).then((result) => result.affectedRowCount);
   }
 
   @override
@@ -536,10 +536,11 @@ class _PostgreSQLResultMetaData {
 
 class _PostgreSQLResult extends UnmodifiableListView<PostgreSQLResultRow>
     implements PostgreSQLResult {
-  final int rowsAffected;
+  @override
+  final int affectedRowCount;
   final _PostgreSQLResultMetaData _metaData;
 
-  _PostgreSQLResult(this.rowsAffected, this._metaData, List<PostgreSQLResultRow> rows)
+  _PostgreSQLResult(this.affectedRowCount, this._metaData, List<PostgreSQLResultRow> rows)
       : super(rows);
 
   @override

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -116,6 +116,6 @@ abstract class PostgreSQLResultRow implements List {
 /// Rows can be accessed through the `[]` operator.
 abstract class PostgreSQLResult implements List<PostgreSQLResultRow> {
   /// How many rows did this query affect?
-  int get rowsAffected;
+  int get affectedRowCount;
   List<ColumnDescription> get columnDescriptions;
 }

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -115,5 +115,7 @@ abstract class PostgreSQLResultRow implements List {
 ///
 /// Rows can be accessed through the `[]` operator.
 abstract class PostgreSQLResult implements List<PostgreSQLResultRow> {
+  /// How many rows did this query affect?
+  int get rowsAffected;
   List<ColumnDescription> get columnDescriptions;
 }

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -26,7 +26,7 @@ class Query<T> {
 
   String statementIdentifier;
 
-  Future<T> get future => _onComplete.future;
+  Future<QueryResult<T>> get future => _onComplete.future;
 
   final String statement;
   final Map<String, dynamic> substitutionValues;
@@ -38,7 +38,7 @@ class Query<T> {
 
   CachedQuery cache;
 
-  final _onComplete = Completer<T>.sync();
+  final _onComplete = Completer<QueryResult<T>>.sync();
   List<FieldDescription> _fieldDescriptions;
 
   List<FieldDescription> get fieldDescriptions => _fieldDescriptions;
@@ -154,11 +154,11 @@ class Query<T> {
     }
 
     if (onlyReturnAffectedRowCount) {
-      _onComplete.complete(rowsAffected as T);
+      _onComplete.complete(QueryResult(rowsAffected, null));
       return;
     }
 
-    _onComplete.complete(rows as T);
+    _onComplete.complete(QueryResult(rowsAffected, rows as T));
   }
 
   void completeError(dynamic error, [StackTrace stackTrace]) {
@@ -171,6 +171,13 @@ class Query<T> {
 
   @override
   String toString() => statement;
+}
+
+class QueryResult<T> {
+  final int rowsAffected;
+  final T value;
+
+  const QueryResult(this.rowsAffected, this.value);
 }
 
 class CachedQuery {

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -174,10 +174,10 @@ class Query<T> {
 }
 
 class QueryResult<T> {
-  final int rowsAffected;
+  final int affectedRowCount;
   final T value;
 
-  const QueryResult(this.rowsAffected, this.value);
+  const QueryResult(this.affectedRowCount, this.value);
 }
 
 class CachedQuery {


### PR DESCRIPTION
Currently `PostgreSQLExecutionContext.query` does not have a way to know how many rows did that particular
query affected. The only way to get that information is to use `PostgreSQLExecutionContext.execute`.

Unfortunately `execute` uses slower, less efficient encoding to talk to the PostgreSQL
server and does not support all data types that `query` supports.

This allows you to use `PostgreSQLExecutionContext.query` for INSERT, UPDATE, DELETE statements
and get the affected row count.